### PR TITLE
Add error handling for when deleting tmpdir fails

### DIFF
--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -507,7 +507,7 @@ class _Cli:
         else:
             answer = None
 
-        self._setup() # sets self.tmpdir
+        self._setup()  # sets self.tmpdir
 
         try:
             tests = runtests(

--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -4,13 +4,13 @@ import configparser
 import os
 import shlex
 import shutil
+import stat
 import sys
 import tempfile
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
 from shutil import which
-import stat
 
 from rich.console import Console
 

--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from functools import partial
 from pathlib import Path
 from shutil import which
+import stat
 
 from rich.console import Console
 
@@ -257,6 +258,7 @@ class _Cli:
         self._stderr_console = Console(file=sys.stderr)
         self._argparser = _ArgumentParser.create_parser()
         self._default_color_system = self._stdout_console.color_system
+        self.tmpdir = None
 
     @property
     def stdout(self):
@@ -437,6 +439,33 @@ class _Cli:
         settings = merge_settings(argument_settings, configuration_settings)
         return settings
 
+    def _setup(self):
+        """
+        Sets up a directory where tests will run (called `tmpdir`).
+        Also set $TMPDIR, $TMP, and $TMP environment variables to a `tmp` dir inside the tmpdir.
+        """
+        self.tmpdir = os.environ["PRYSK_TEMP"] = tempfile.mkdtemp("", "prysk-tests-")
+        self.tmpdir = Path(self.tmpdir)
+        proc_tmp = self.tmpdir / "tmp"
+        for name in ("TMPDIR", "TEMP", "TMP"):
+            os.environ[name] = f"{proc_tmp}"
+
+        os.mkdir(proc_tmp)
+
+    def _cleanup(self):
+        """
+        A wrapper for #shutil.rmtree() that can try to remove write protection
+        if removing fails, if enabled.
+        """
+        if self.tmpdir is None:
+            return
+
+        def on_rm_error(func, path, exc_info):
+            os.chmod(path, stat.S_IWRITE)
+            os.unlink(path)
+
+        shutil.rmtree(self.tmpdir, onerror=on_rm_error)
+
     def main(self, argv=None):
         try:
             settings = self._load_settings(argv)
@@ -478,17 +507,12 @@ class _Cli:
         else:
             answer = None
 
-        tmpdir = os.environ["PRYSK_TEMP"] = tempfile.mkdtemp("", "prysk-tests-")
-        tmpdir = Path(tmpdir)
-        proc_tmp = tmpdir / "tmp"
-        for name in ("TMPDIR", "TEMP", "TMP"):
-            os.environ[name] = f"{proc_tmp}"
+        self._setup() # sets self.tmpdir
 
-        os.mkdir(proc_tmp)
         try:
             tests = runtests(
                 settings.tests,
-                tmpdir,
+                self.tmpdir,
                 shell,
                 indent=settings.indent,
                 cleanenv=not settings.preserve_env,
@@ -521,6 +545,6 @@ class _Cli:
             return ExitCode.TEST_FAILED if failed else ExitCode.SUCCESS
         finally:
             if settings.keep_tmpdir:
-                self.stdout(f"# Kept temporary directory: [blue]{tmpdir}[/blue]")
+                self.stdout(f"# Kept temporary directory: [blue]{self.tmpdir}[/blue]")
             else:
-                shutil.rmtree(tmpdir)
+                self._cleanup()


### PR DESCRIPTION
On Windows, if there are open file handles in the tmpdir, rmtree will fail. To get around this, first attempt to make the path writable first.

This commit also moves the setup of the tmpdir into a private function so setup/cleanup are symmetrical

Maybe fixes #206. I'm not sure how to easily test this patch in a Windows machine