### PR TITLE
Fix prysk test file lookup for explicitly specified hidden files/directories

### DIFF
--- a/docs/prysk_news.rst
+++ b/docs/prysk_news.rst
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Fix prysk test file lookup for explicitly specified hidden files/directories
+    * Fixes `#224 <https://github.com/prysk/prysk/issues/224>`_
 
 Version 0.16.0 (Nov. 24, 2023)
 -------------------------------

--- a/test/unit/test_test.py
+++ b/test/unit/test_test.py
@@ -14,28 +14,26 @@ def create_directory(root, name):
 
 def create_file(directory, name, data):
     file = Path(directory) / name
-    file.touch()
-    with open(file, "w") as f:
-        f.write(data)
+    file.write_text(data)
     return file
 
 
-def test_findtests_ignores_hidden_file_in_current_directory(tmpdir):
-    file = create_file(tmpdir, "default.t", "")
+def test_findtests_ignores_hidden_file_in_current_directory(tmp_path):
+    file = create_file(tmp_path, "default.t", "")
     expected = (Path(file.name),)
-    with cwd(tmpdir):
+    with cwd(tmp_path):
         assert tuple(_findtests([file.name])) == expected
 
 
-def test_findtests_ignores_hidden_files(tmpdir):
-    _ = create_file(tmpdir, ".hidden.t", "")
-    visible_file = create_file(tmpdir, "visible.t", "")
+def test_findtests_ignores_hidden_files(tmp_path):
+    _ = create_file(tmp_path, ".hidden.t", "")
+    visible_file = create_file(tmp_path, "visible.t", "")
     expected = (visible_file,)
-    assert tuple(_findtests([tmpdir])) == expected
+    assert tuple(_findtests([tmp_path])) == expected
 
 
-def test_findtests_ignores_folders(tmpdir):
-    hidden_directory = create_directory(tmpdir, ".hidden")
+def test_findtests_ignores_folders(tmp_path):
+    hidden_directory = create_directory(tmp_path, ".hidden")
     _ = create_file(hidden_directory, "visible.t", "")
     expected = tuple()
-    assert tuple(_findtests([tmpdir])) == expected
+    assert tuple(_findtests([tmp_path])) == expected

--- a/test/unit/test_test.py
+++ b/test/unit/test_test.py
@@ -37,3 +37,19 @@ def test_findtests_ignores_folders(tmp_path):
     _ = create_file(hidden_directory, "visible.t", "")
     expected = tuple()
     assert tuple(_findtests([tmp_path])) == expected
+
+
+def test_findtests_accepts_explicit_files(tmp_path):
+    file1 = create_file(tmp_path, "default.md", "")
+    file2 = create_file(tmp_path, ".hidden.t", "")
+    expected = (file1, file2)
+    assert tuple(_findtests([file1, file2])) == expected
+
+
+def test_findtests_accepts_explicit_dirs(tmp_path):
+    hidden_directory = create_directory(tmp_path, ".hidden")
+    hidden_subdir = create_directory(hidden_directory, ".hidden_subdir")
+    file = create_file(hidden_directory, "visible.t", "")
+    _ = create_file(hidden_subdir, "sub_visible.t", "")
+    expected = (file,)
+    assert tuple(_findtests([hidden_directory])) == expected

--- a/test/unit/test_test.py
+++ b/test/unit/test_test.py
@@ -32,7 +32,7 @@ def test_findtests_ignores_hidden_files(tmp_path):
     assert tuple(_findtests([tmp_path])) == expected
 
 
-def test_findtests_ignores_folders(tmp_path):
+def test_findtests_ignores_hidden_folders(tmp_path):
     hidden_directory = create_directory(tmp_path, ".hidden")
     _ = create_file(hidden_directory, "visible.t", "")
     expected = tuple()


### PR DESCRIPTION
This restores the original cram behaviour of not ignoring files without a .t suffix, hidden files or hidden directories when these are explicitly specified on the command line.

(is_hidden and is_testfile can be moved back into _findtests as the pytest plugin went away; is_hidden no longer needs to account for relative paths as Path.relative_to drops all the irrelevant parts)

Fixes: https://github.com/prysk/prysk/issues/224
