### PR TITLE
pyproject.toml: Only use `include` for sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,16 +40,16 @@ keywords = [
 repository = "https://github.com/Nicoretti/prysk"
 homepage = "https://www.prysk.net/"
 include = [
-    ".coveragerc",
-    "noxfile.py",
-    "poetry.lock",
-    "*.rst",
-    "*.txt",
-    "*.toml",
-    "docs/*",
-    "contrib/*",
-    "scripts/*",
-    "examples/*",
+    { path = ".coveragerc", format = "sdist" },
+    { path = "noxfile.py", format = "sdist" },
+    { path = "poetry.lock", format = "sdist" },
+    { path = "*.rst", format = "sdist" },
+    { path = "*.txt", format = "sdist" },
+    { path = "*.toml", format = "sdist" },
+    { path = "docs/*", format = "sdist" },
+    { path = "contrib/*", format = "sdist" },
+    { path = "scripts/*", format = "sdist" },
+    { path = "examples/*", format = "sdist" },
 ]
 exclude = [
     "contrib/PKGBUILD",


### PR DESCRIPTION
Otherwise they end up in the root of site-packages, for example at:
/usr/lib/python3.11/site-packages/README.rst

Which causes issues when multiple packages are installed.

https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
