### PR TITLE
Don't escape lines that decode as UTF-8 and are printable, by default

### DIFF
--- a/docs/prysk_news.rst
+++ b/docs/prysk_news.rst
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+* Printable UTF-8 isn't escaped by default any more. Use :code:`--escape7bit`
+  to get the old behaviour. (`#232 <https://github.com/prysk/prysk/issues/232>`_)
+
 Version 0.19.0 (March. 23, 2024)
 -------------------------------
 

--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -197,6 +197,11 @@ class _ArgumentParser:
             action="store_true",
             help="convert DOS/Windows line endings to UNIX line endings",
         )
+        parser.add_argument(
+            "--escape7bit",
+            action="store_true",
+            help="escape all non-7-bit bytes (not just non-printable/invalid UTF-8)",
+        )
         return parser
 
     def __init__(self, *args, **kwargs):
@@ -518,6 +523,7 @@ class _Cli:
                 cleanenv=not settings.preserve_env,
                 debug=settings.debug,
                 dos2unix=settings.dos2unix,
+                escape7bit=settings.escape7bit,
             )
             if not settings.debug:
                 tests = self._runcli(

--- a/prysk/settings.py
+++ b/prysk/settings.py
@@ -22,6 +22,7 @@ class Settings:
     color: str = "auto"
     xunit_file: str = None
     dos2unix: bool = None
+    escape7bit: bool = None
 
 
 def settings_from(obj):

--- a/test/integration/prysk/encoding.t
+++ b/test/integration/prysk/encoding.t
@@ -10,6 +10,9 @@ Test with Windows newlines:
   # Ran 1 tests, 0 skipped, 0 failed.
 
   $ printf "  $ echo hi_from_windows\r\n  hi_from_windows\n" > windows-newlines-dos2unix.t
+  $ printf "  $ echo hi_from_windows\r\n  hi_from_windows\r\n" > windows-newlines-dos2unix.t
+  $ printf "  $ echo 'hi_from_windows\r'\n  hi_from_windows\n" > windows-newlines-dos2unix.t
+  $ printf "  $ echo 'hi_from_windows\r'\n  hi_from_windows\r\n" > windows-newlines-dos2unix.t
   $ printf "  $ echo hi_from_unix\n  hi_from_unix\n" >> windows-newlines-dos2unix.t
   $ prysk windows-newlines-dos2unix.t --dos2unix
   .

--- a/test/integration/prysk/encoding.t
+++ b/test/integration/prysk/encoding.t
@@ -54,16 +54,21 @@ Test with UTF-8 encoding:
   $ cat > bad-utf-8.t <<EOF
   >   $ printf "hola se\303\261or\n"
   >   hey
+  >   $ printf "hola \377 se\303\261or\n"
+  >   hey
   > EOF
 
   $ prysk good-utf-8.t bad-utf-8.t
   .!
   --- bad-utf-8.t
   +++ bad-utf-8.t.err
-  @@ -1,2 +1,2 @@
+  @@ -1,4 +1,4 @@
      $ printf "hola se\303\261or\n"
   -  hey
   \+  hola señor (re)
+     $ printf "hola \377 se\303\261or\n"
+  -  hey
+  \+  hola \\xff señor \(esc\) (re)
   
   # Ran 2 tests, 0 skipped, 1 failed.
   [1]
@@ -72,10 +77,13 @@ Test with UTF-8 encoding:
   .!
   --- bad-utf-8.t
   +++ bad-utf-8.t.err
-  @@ -1,2 +1,2 @@
+  @@ -1,4 +1,4 @@
      $ printf "hola se\303\261or\n"
   -  hey
   \+  hola se\\xc3\\xb1or \(esc\) (re)
+     $ printf "hola \377 se\303\261or\n"
+  -  hey
+  \+  hola \\xff se\\xc3\\xb1or \(esc\) (re)
   
   # Ran 2 tests, 0 skipped, 1 failed.
   [1]

--- a/test/integration/prysk/encoding.t
+++ b/test/integration/prysk/encoding.t
@@ -46,6 +46,8 @@ Test with UTF-8 encoding:
 
   $ cat > good-utf-8.t <<EOF
   >   $ printf "hola se\303\261or\n"
+  >   hola señor
+  >   $ printf "hola se\303\261or\n"
   >   hola se\xc3\xb1or (esc)
   > EOF
 
@@ -55,6 +57,18 @@ Test with UTF-8 encoding:
   > EOF
 
   $ prysk good-utf-8.t bad-utf-8.t
+  .!
+  --- bad-utf-8.t
+  +++ bad-utf-8.t.err
+  @@ -1,2 +1,2 @@
+     $ printf "hola se\303\261or\n"
+  -  hey
+  \+  hola señor (re)
+  
+  # Ran 2 tests, 0 skipped, 1 failed.
+  [1]
+
+  $ prysk --escape7bit good-utf-8.t bad-utf-8.t
   .!
   --- bad-utf-8.t
   +++ bad-utf-8.t.err

--- a/test/integration/prysk/usage.t
+++ b/test/integration/prysk/usage.t
@@ -35,6 +35,8 @@ Usage:
     --xunit-file PATH     path to write xUnit XML output (default: None)
     --dos2unix            convert DOS/Windows line endings to UNIX line endings
                           (default: False)
+    --escape7bit          escape all non-7-bit bytes (not just non-
+                          printable/invalid UTF-8) (default: False)
 
 
 


### PR DESCRIPTION
## Background & Context

As I mentioned in https://github.com/prysk/prysk/issues/224, I've been using cram (and now prysk) for years to make sure the examples in my README.md files are up to date. Some of those READMEs, however, contain example output with printable Unicode characters that aren't in 7-bit ASCII. I need those examples to be human-readable, and prysk's escaping messes that up.

To be precise, both cram and prysk accept unescaped UTF-8 in the tests, and if those tests pass, everything works just fine. When the tests fail, however, the diff presented by cram/prysk will be full of unnecessary escaping, and interactively applying the diff will introduce unnecessary escapes into the test files.

## Description

This pull request addresses the issue by changing the default escaping algorithm to skip escaping valid printable UTF-8 characters. The old behaviour is available via the `--escape7bit` option. Note that existing tests are not affected (unless there is an error in my implementation), as all the escaping is undone during diffing. Only the presentation of diffs of failing tests is changed, in both interactive and non-interactive modes of operation.

The PR is split into several commits: 2 prep ones, then a simple stupid implementation of the improved escaping algorithm, and the last commit implements a more complex escaping algorithm that preserves as much unescaped characters as possible, and only escapes what's absolutely necessary. If that additional complexity isn't desirable, we can revert that one…

Fixes: https://github.com/prysk/prysk/issues/232
