### PR TITLE
test: add execute_func parameter

### DIFF
--- a/prysk/test.py
+++ b/prysk/test.py
@@ -149,6 +149,7 @@ def test(
     debug=False,
     dos2unix=False,
     escape7bit=False,
+    execute_func=False
 ):
     r"""Run test lines and return input, output, and diff.
 
@@ -209,6 +210,8 @@ def test(
     :param escape7bit: Whether to escape all non-7-bit bytes or only
       non-printable/invalid UTF-8
     :type escape7bit: bool
+    :param execute_func: Callback function to use instead of shell
+    :type exectue_func: Python function
     return: Input, output, and diff iterables
     :rtype: (list[bytes], list[bytes], collections.Iterable[bytes])
     """
@@ -259,9 +262,12 @@ def test(
             after.setdefault(pos, []).append(line)
     stdin.append(b"echo %s %d $?\n" % (salt, i + 1))
 
-    output, retcode = execute(
-        shell + ["-"], stdin=b"".join(stdin), stdout=PIPE, stderr=STDOUT, env=env
-    )
+    if execute_func:
+        output, retcode = execute_func(stdin)
+    else:
+        output, retcode = execute(
+            shell + ["-"], stdin=b"".join(stdin), stdout=PIPE, stderr=STDOUT, env=env
+        )
     if retcode == _SKIP:
         return refout, None, []
 
@@ -340,6 +346,7 @@ def testfile(
     testname=None,
     dos2unix=False,
     escape7bit=False,
+    execute_func=False,
 ):
     """Run test at path and return input, output, and diff.
 
@@ -374,6 +381,8 @@ def testfile(
     :param escape7bit: Whether to escape all non-7-bit bytes or only
       non-printable/invalid UTF-8
     :type escape7bit: bool
+    :param execute_func: Callback function to use instead of shell
+    :type exectue_func: Python function
     :return: Input, output, and diff iterables
     :rtype: (list[bytes], list[bytes], collections.Iterable[bytes])
     """
@@ -394,6 +403,7 @@ def testfile(
             debug=debug,
             dos2unix=dos2unix,
             escape7bit=escape7bit,
+            execute_func=execute_func,
         )
 
 
@@ -406,6 +416,7 @@ def runtests(
     debug=False,
     dos2unix=False,
     escape7bit=False,
+    execute_func=False,
 ):
     """Run tests and yield results.
 
@@ -450,6 +461,7 @@ def runtests(
                     testname=path,
                     dos2unix=dos2unix,
                     escape7bit=escape7bit,
+                    execute_func=execute_func,
                 )
 
         yield path, test

--- a/test/unit/test_test.py
+++ b/test/unit/test_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from prysk.test import (
     _findtests,
     cwd,
+    testfile
 )
 
 
@@ -53,3 +54,11 @@ def test_findtests_accepts_explicit_dirs(tmp_path):
     _ = create_file(hidden_subdir, "sub_visible.t", "")
     expected = (file,)
     assert tuple(_findtests([hidden_directory])) == expected
+
+
+def test_execute_func(tmp_path):
+    def shell_wrapper_reverse(cmd):
+        return b"ko", 0
+
+    file1 = create_file(tmp_path, "default.md", "  $ echo 'ok'\n  ko\n")
+    testfile(file1, execute_func=shell_wrapper_reverse)


### PR DESCRIPTION
I'm currently using [Labgrid](https://github.com/labgrid-project) to test different WiFi routers. Cram aka Prysk seems like a nice alternative for people that are not familiar with writing Python Pytest, so I'd like to use it. A limitation is that those devices need a bunch of bootstrapping, so you want to let Labgrid do its magic and then use their wrapper functions, i.e. `stdout, stderr, returncode = ssh_command.run(cmd)`. This doesn't fly with the *shell parameter* since a bunch of timing is required.

With this change you can use those wrapper/callback functions which is a first step towards integrating Prysk into the test setup. The second step is integrating it into `pytest-prysk` which I'm struggling with right now, since I don't know how to add fixture to dynamic tests...

Here is my current setup:

```python
@pytest.fixture
def prysk_wrapper(shell_command):
    def _prysk_wrapper(command):
        data, _, returncode = shell_command.run((b"".join(command)).decode("utf-8"))
        return ("\n".join(data) + "x").encode(), returncode

    return _prysk_wrapper


def test_cram(prysk_wrapper):
    refout, postout, diff = prysk.test.testfile(
        Path("tests/cram/base.t"), execute_func=prysk_wrapper
    )
```