### PR TITLE
Fix #272 (ignoring cli-specified --shell-opts)

### DIFF
--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -492,7 +492,7 @@ class _Cli:
             return ExitCode.ERROR
         shell = [shellcmd]
         if settings.shell_opts:
-            shell += shlex.split(settings.shell_opts)
+            shell += settings.shell_opts
 
         patchcmd = None
         if settings.interactive:

--- a/prysk/settings.py
+++ b/prysk/settings.py
@@ -1,4 +1,5 @@
 import argparse
+import shlex
 from dataclasses import (
     dataclass,
     field,
@@ -23,6 +24,12 @@ class Settings:
     xunit_file: str = None
     dos2unix: bool = None
     escape7bit: bool = None
+
+    def __post_init__(self):
+        if isinstance(self.shell_opts, str):
+            self.shell_opts = shlex.split(self.shell_opts)
+        elif self.shell_opts is None:
+            self.shell_opts = []
 
 
 def settings_from(obj):
@@ -51,7 +58,7 @@ def settings_from(obj):
 def merge_settings(lhs, rhs):
     def items(d):
         d = vars(d)
-        excludes = ["tests"]
+        excludes = ["tests", "shell_opts"]
         return ((k, v) for k, v in d.items() if k not in excludes)
 
     lhs_items = dict(items(lhs))


### PR DESCRIPTION
This is one way to fix the issue.

It suggests something similar maybe be necessary for the `tests` setting.

Alternative solutions may be replacing plain dataclasses with use of attrs/cattrs.

No new tests are included here . . . yet.

---

Is this a good approach, or not? If it's good, please feel free to add a test, or I can get to it eventually.